### PR TITLE
Fix Timers Snippets

### DIFF
--- a/snippets/meteor-api-snippets-coffeescript.cson
+++ b/snippets/meteor-api-snippets-coffeescript.cson
@@ -314,13 +314,13 @@
 
   'Meteor.setTimeout':
     'prefix': 'setTimeout'
-    'body': 'Match.setTimeout (->
+    'body': 'Meteor.setTimeout (->
     \n\t$2
     \n${1:milliseconds})'
 
   'Meteor.setInterval':
     'prefix': 'setInterval'
-    'body': 'Match.setTimeout (->
+    'body': 'Meteor.setTimeout (->
     \n\t$2
     \n${1:milliseconds})'
 


### PR DESCRIPTION
There is an error in first two timers snippets. It should be Meteor instead of Match.
